### PR TITLE
Adding linkedDocuments on a document's template + bump to 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "express": "3.4.1",
     "ejs": "*",
     "ejs-locals": "~1.0.2",
-    "prismic.io": "1.0.11"
+    "prismic.io": "1.0.12"
   },
   "repository" : { "type" : "git", "url" : "http://github.com/prismicio/javascript-nodejs-starter.git" }
 }

--- a/views/detail.ejs
+++ b/views/detail.ejs
@@ -3,3 +3,19 @@
 <article>
     <%- doc.asHtml(ctx) %>
 </article>
+
+<% if (doc.linkedDocuments.length > 0) { %>
+	<hr>
+	<aside>
+		<h2>Linked documents</h2>
+		<ul>
+			<% doc.linkedDocuments.forEach(function(linkedDocument){ %>
+				<li>
+					<a href="/documents/<%= linkedDocument.id %>/<%= linkedDocument.slug %>">
+						<%= linkedDocument.slug %>
+					</a>
+				</li>
+			<% }); %>
+		</ul>
+	</aside>
+<% } %>


### PR DESCRIPTION
Making good use of the brand new linked documents exposed in the API, and listing them in the "document" template.

**Careful: do not merge this as long as the linked documents feature is not live in all repository APIs!**